### PR TITLE
Add link to capybara-chrome

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@
 - [puppeteer-sharp](https://github.com/kblok/puppeteer-sharp) - Port of Puppeteer to .NET.
 - [foxr](https://github.com/deepsweet/foxr) - Node.js API to control Firefox. 🦊
 - [pyppeteer](https://github.com/miyakogi/pyppeteer) - Unofficial Python port of Puppeteer.
+- [capybara-chrome](https://github.com/carezone/capybara-chrome) – Capybara driver (Ruby) that uses the Chrome DevTools Protocol to drive headless chrome.
 
 
 ## Contribute

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@
 - [puppeteer-sharp](https://github.com/kblok/puppeteer-sharp) - Port of Puppeteer to .NET.
 - [foxr](https://github.com/deepsweet/foxr) - Node.js API to control Firefox. 🦊
 - [pyppeteer](https://github.com/miyakogi/pyppeteer) - Unofficial Python port of Puppeteer.
-- [capybara-chrome](https://github.com/carezone/capybara-chrome) – Capybara driver (Ruby) that uses the Chrome DevTools Protocol to drive headless chrome.
+- [capybara-chrome](https://github.com/carezone/capybara-chrome) – Unofficial Ruby port of Puppeteer.
 
 
 ## Contribute


### PR DESCRIPTION
While capybara-chrome isn't a direct port of Puppeteer to Ruby, the code is heavily influenced by the design of Puppeteer.