### PR TITLE
Updated Readme. Added FusionExport.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,7 @@
 - [checkly](https://checklyhq.com) - Monitoring SaaS that uses Puppeteer to check availability and correctness of web pages and apps.
 - [url-to-pdf-api](https://github.com/alvarcarto/url-to-pdf-api) - Web page PDF rendering done right. Self-hosted service for rendering.
 - [browserless](https://github.com/joelgriffith/browserless) - Headless Chrome as a service letting you execute Puppeteer scripts remotely.
+- [FusionExport](https://www.fusioncharts.com/fusionexport) - FusionExport enables you to convert your live dashboards to PDF or images. It works with all JavaScript charting libraries (FusionCharts, HighCharts, d3, Chart.js or others) and is easy to install. It includes SDKs for Java, Node.js, C#, Go and many more.
 
 
 ## Examples

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@
 - [checkly](https://checklyhq.com) - Monitoring SaaS that uses Puppeteer to check availability and correctness of web pages and apps.
 - [url-to-pdf-api](https://github.com/alvarcarto/url-to-pdf-api) - Web page PDF rendering done right. Self-hosted service for rendering.
 - [browserless](https://github.com/joelgriffith/browserless) - Headless Chrome as a service letting you execute Puppeteer scripts remotely.
-- [FusionExport](https://www.fusioncharts.com/fusionexport) - FusionExport enables you to convert your live dashboards to PDF or images. It works with all JavaScript charting libraries (FusionCharts, HighCharts, d3, Chart.js or others) and is easy to install. It includes SDKs for Java, Node.js, C#, Go and many more.
+- [FusionExport](https://www.fusioncharts.com/fusionexport) - Export dashboards or charts to PDF or images. Looks mature.
 
 
 ## Examples


### PR DESCRIPTION
FusionExport's core uses puppeteer from it's beginning. It supports exporting any charts or dashboards to PDF, PNG, JPEG, SVG, HTML etc. 
It includes SDKs for Java, Node.js, C#, Golang,  Python and PHP