### PR TITLE
Adding axe-puppeteer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@
 - [tupe](https://github.com/jl-/tupe) - A generic unit-testing runner for front-end.
 - [puppetry](https://puppetry.app/) - Scriptless E2E test automation tool.
 - [wendigo](https://github.com/angrykoala/wendigo) - Puppeteer wrapper to ease test development.
+- [axe-puppeteer](https://github.com/dequelabs/axe-puppeteer) - Automated accessiblity Web UI testing.
 
 ## Services
 


### PR DESCRIPTION
This library integrates aXe-core with Puppeteer. I'm currently using it to do some automated a11y testing with the Government of Canada.

aXe-Core is an Open Source Accessibility (a11y) automation library.

It's the library that Lighthouse is built on top of. While Lighthouse is pretty good for a11y testing aXe will catch a couple more a11y issues then lighthouse.

Here is a blog post explaining the connection between them.

https://codeburst.io/the-engine-driving-web-accessibility-standardization-4515d87250ca
