### PR TITLE
Fix official examples broken url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@
 
 ## Examples
 
-- [Official examples](https://github.com/GoogleChrome/puppeteer/tree/master/examples/) - Quality examples as part of the official puppeteer repo.
+- [Official examples](https://github.com/puppeteer/puppeteer/tree/main/examples) - Quality examples as part of the official puppeteer repo.
 - [Official use case-driven examples](https://github.com/GoogleChromeLabs/puppeteer-examples) - More complex, high quality, use case-driven examples.
 - [puppeteer-examples](https://github.com/checkly/puppeteer-examples) - Quality examples for real life use cases such as scraping web pages and common login scenarios.
 - [puppeteer-samples](https://github.com/sweekson/puppeteer-samples) - Misc examples.

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -89,7 +89,7 @@
 
 ## 例子
 
--   [官方 例子](https://github.com/GoogleChrome/puppeteer/tree/master/examples/)- 作为官方Puppeteer的一部分的优质示例. 
+-   [官方 例子](https://github.com/puppeteer/puppeteer/tree/main/examples)- 作为官方Puppeteer的一部分的优质示例. 
 -   [官方 使用 case-driven 例子](https://github.com/GoogleChromeLabs/puppeteer-examples)- 更复杂,高质量,用例驱动的示例. 
 -   [puppeteer-examples](https://github.com/checkly/puppeteer-examples)- 实际使用案例的质量示例,例如抓取网页和常见登录方案. 
 -   [puppeteer-samples](https://github.com/sweekson/puppeteer-samples)- 其他例子. 


### PR DESCRIPTION
The official examples url `https://github.com/GoogleChrome/puppeteer/tree/master/examples/` no longer points to the puppeteer repository
because the master branch has been renamed to main branch.

This commit updates the aforementioned url to `https://github.com/puppeteer/puppeteer/tree/main/examples`