### PR TITLE
docs: add theheadless.dev to guides

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@
 - [Services](#services)
 - [Examples](#examples)
 - [Articles](#articles)
+- [Guides](#guides)
 - [Related](#related)
 
 
@@ -125,6 +126,10 @@
 - [Chromeless, Chrominator, Chromy, Navalia, Lambdium, GhostJS, AutoGCD](https://medium.com/@kensoh/chromeless-chrominator-chromy-navalia-lambdium-ghostjs-autogcd-ef34bcd26907) - Alternative Headless Chrome Projects.
 - [What's the difference between Chromium and Chrome?](https://www.howtogeek.com/202825/what%E2%80%99s-the-difference-between-chromium-and-chrome/)
 - [NodeJs Scraping with Puppeteer](https://learnscraping.com/nodejs-web-scraping-with-puppeteer/) - IMDB Scraping example.
+
+## Guides
+
+- [theheadless.dev](https://theheadless.dev) - Practical guides and runnable examples on Puppeteer (and Playwright).
 
 ## Related
 


### PR DESCRIPTION
Adding theheadless.dev under new section "Guides"