### PR TITLE
Add rialto-php/puphpeteer - PHP port of Puppeteer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@
 - [foxr](https://github.com/deepsweet/foxr) - Node.js API to control Firefox. 🦊
 - [pyppeteer](https://github.com/pyppeteer/pyppeteer) - Unofficial Python port of Puppeteer.
 - [capybara-chrome](https://github.com/carezone/capybara-chrome) – Unofficial Ruby port of Puppeteer.
+- [puphpeteer](https://github.com/rialto-php/puphpeteer) - PHP port of Puppeteer.
 
 
 ## Contribute


### PR DESCRIPTION
Contributing with a leading PHP port of Puppeteer https://github.com/rialto-php/puphpeteer