### PR TITLE
Add BrowserCat to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@
 - [FloodRunner](https://floodrunner.dev) - Open-source monitoring solution using puppeteer tests.
 - [The Browser Conference](https://www.accelevents.com/e/the-browser-conference-23) - A free half-day virtual conference focused on Browser Automation, Data Extraction and Testing.
 - [Doczilla](https://www.doczilla.app) - SaaS API empowering the generation of screenshots or PDFs directly from HTML/CSS/JS code.
-
+- [BrowserCat](https://www.browsercat.com) - Hosted Chrome/Chromium to deploy and scale your Puppeteer scripts affordably and reliably. Offers forever-free plan.
 
 ## Examples
 


### PR DESCRIPTION
BrowserCat supports connecting Puppeteer to hosted Chrome/Chromium instances. Most affordable option available, and it offers a good free plan.